### PR TITLE
fix(urlMatcherFactory): Decode slashes in string routes

### DIFF
--- a/src/urlMatcherFactory.js
+++ b/src/urlMatcherFactory.js
@@ -579,7 +579,7 @@ function $UrlMatcherFactory() {
       decode: valFromString,
       // TODO: in 1.0, make string .is() return false if value is undefined/null by default.
       // In 0.2.x, string params are optional by default for backwards compat
-      is: function(val) { return (val == null || !isDefined(val) || typeof val === "string") && (val.toString().indexOf(slashReplacement) === -1); },
+      is: function(val) { return val == null || !isDefined(val) || (isString(val) && val.indexOf(slashReplacement) === -1); },
       pattern: /[^/]*/
     },
     int: {

--- a/src/urlMatcherFactory.js
+++ b/src/urlMatcherFactory.js
@@ -568,8 +568,9 @@ function $UrlMatcherFactory() {
   $$UMFP = this;
 
   var isCaseInsensitive = false, isStrictMode = true, defaultSquashPolicy = false;
+  var slashReplacement = "%2F";
 
-  function valToString(val) { return val != null ? val.toString().replace(/\//g, "%2F") : val; }
+  function valToString(val) { return val != null ? val.toString().replace(/\//g, slashReplacement) : val; }
   function valFromString(val) { return val != null ? val.toString().replace(/%2F/g, "/") : val; }
 
   var $types = {}, enqueue = true, typeQueue = [], injector, defaultTypes = {
@@ -578,7 +579,7 @@ function $UrlMatcherFactory() {
       decode: valFromString,
       // TODO: in 1.0, make string .is() return false if value is undefined/null by default.
       // In 0.2.x, string params are optional by default for backwards compat
-      is: function(val) { return val == null || !isDefined(val) || typeof val === "string"; },
+      is: function(val) { return (val == null || !isDefined(val) || typeof val === "string") && (val.toString().indexOf(slashReplacement) === -1); },
       pattern: /[^/]*/
     },
     int: {

--- a/test/urlMatcherFactorySpec.js
+++ b/test/urlMatcherFactorySpec.js
@@ -65,6 +65,7 @@ describe("UrlMatcher", function () {
     var matcher = new UrlMatcher('/:foo');
     expect(matcher.format({ foo: "/" })).toBe('/%252F');
     expect(matcher.format({ foo: "//" })).toBe('/%252F%252F');
+    expect(matcher.exec('/hello%2Fworld')).toEqual({ foo: 'hello/world' });
   });
 
   describe("snake-case parameters", function() {


### PR DESCRIPTION
Slashes in string routes now get decoded (they were only encoded before). Related test was fixed.

The current behavior is the following: Encoding the state parameter hello/world correctly gets encoded to hello%252Fworld, but reading it from the target controller returns hello%2Fworld. This is because the value is recognized as a valid string and therefore isn’t decoded. Fixing the is function of the string type now triggers the decode of slashes.

In addition, the related tests was fixed. The description says that encoding and decoding is tested, however only encoding tests take place.